### PR TITLE
get_pdo -> get_dbh

### DIFF
--- a/data/tt-rss-feedreader-plugin/api_feedreader/init.php
+++ b/data/tt-rss-feedreader-plugin/api_feedreader/init.php
@@ -20,7 +20,7 @@ class Api_feedreader extends Plugin {
 	function init($host)
 	{
 		$this->host = $host;
-		$this->dbh = $host->get_pdo();
+		$this->dbh = $host->get_dbh();
 		$this->host->add_api_method("addLabel", $this);
 		$this->host->add_api_method("removeLabel", $this);
 		$this->host->add_api_method("renameLabel", $this);


### PR DESCRIPTION
There seems to be a change in functions in tt-rss which kills tt-rss when the plugin is active. After changing get_pdo to get_dbh it works again.